### PR TITLE
Add switch for multiple automata types

### DIFF
--- a/src/main/java/owl/gfmMinimisation.java
+++ b/src/main/java/owl/gfmMinimisation.java
@@ -1,12 +1,20 @@
 package owl;
 
+import owl.automaton.Automaton;
 import owl.automaton.acceptance.BuchiAcceptance;
+import owl.automaton.acceptance.EmersonLeiAcceptance;
+import owl.automaton.acceptance.ParityAcceptance;
+import owl.automaton.acceptance.RabinAcceptance;
+import owl.automaton.acceptance.degeneralization.RabinDegeneralization;
+import owl.automaton.acceptance.optimization.AcceptanceOptimizations;
 import owl.automaton.hoa.HoaWriter;
 import owl.ltl.LabelledFormula;
 import owl.ltl.parser.LtlfParser;
 import owl.translations.LtlTranslationRepository;
 import owl.translations.ltl2ldba.AnnotatedLDBA;
 import owl.translations.ltl2ldba.AsymmetricLDBAConstruction;
+import owl.translations.rabinizer.RabinizerBuilder;
+import owl.translations.rabinizer.RabinizerConfiguration;
 
 import java.io.FileWriter;
 import java.io.IOException;
@@ -20,24 +28,22 @@ public class gfmMinimisation {
 
 //        LabelledFormula inputFormula = LtlfParser.parse("GF(a & X(X(X(b))))");
 //        LabelledFormula inputFormula = LtlfParser.parse("GF a & GF b & GF c");
-        LabelledFormula inputFormula = null;
+        if (args.length < 2) {
+            System.out.println("Usage: <type> <ltl formula>");
+            return;
+        }
 
+        String translation = args[0];
 
-        // get all args and merge them together in case of white-space
+        // merge remaining args to obtain the formula
         StringBuilder sb = new StringBuilder();
-        for (String arg : args) {
-            sb.append(arg).append(" ");
+        for (int i = 1; i < args.length; i++) {
+            sb.append(args[i]).append(" ");
         }
         String mergedArgs = sb.toString().trim();
 
-        // get input from command line argument
-        if (args.length > 0) {
-            inputFormula = LtlfParser.parse(mergedArgs);
-            System.out.printf("Input formula: %s\n", inputFormula);
-        } else {
-            System.out.println("No input formula provided.");
-            System.exit(1);
-        }
+        LabelledFormula inputFormula = LtlfParser.parse(mergedArgs);
+        System.out.printf("Input formula: %s\n", inputFormula);
 
 
 //        var ldba = AsymmetricLDBAConstruction.of(BuchiAcceptance.class).apply(inputFormula).copyAsMutable();
@@ -48,14 +54,44 @@ public class gfmMinimisation {
         translationOptions.add(LtlTranslationRepository.Option.SIMPLIFY_FORMULA);
         translationOptions.add(LtlTranslationRepository.Option.USE_PORTFOLIO_FOR_SYNTACTIC_LTL_FRAGMENTS);
 
-        var ldbaPostprocessed = applyPreAndPostProcessing(AsymmetricLDBAConstruction.of(BuchiAcceptance.class).andThen(AnnotatedLDBA::copyAsMutable),
-                LtlTranslationRepository.BranchingMode.DETERMINISTIC,
-                translationOptions,
-                BuchiAcceptance.class)
-                .apply(inputFormula);
+        Automaton<?, ?> automaton;
 
+        switch (translation.toLowerCase()) {
+            case "dela" -> automaton =
+                    LtlTranslationRepository.LtlToDelaTranslation.DEFAULT
+                            .translation(EmersonLeiAcceptance.class, translationOptions)
+                            .apply(inputFormula);
 
-        var automataString = HoaWriter.toString(ldbaPostprocessed);
+            case "dpa" -> automaton =
+                    LtlTranslationRepository.LtlToDpaTranslation.DEFAULT
+                            .translation(ParityAcceptance.class, translationOptions)
+                            .apply(inputFormula);
+
+            case "dra" -> {
+                var dgra = RabinizerBuilder.build(inputFormula, RabinizerConfiguration.of(true, true, true));
+                automaton = RabinDegeneralization.degeneralize(AcceptanceOptimizations.transform(dgra));
+            }
+
+            case "nba" -> automaton =
+                    LtlTranslationRepository.LtlToNbaTranslation.DEFAULT
+                            .translation(BuchiAcceptance.class, translationOptions)
+                            .apply(inputFormula);
+
+            case "ldba" -> automaton =
+                    applyPreAndPostProcessing(
+                            AsymmetricLDBAConstruction.of(BuchiAcceptance.class).andThen(AnnotatedLDBA::copyAsMutable),
+                            LtlTranslationRepository.BranchingMode.DETERMINISTIC,
+                            translationOptions,
+                            BuchiAcceptance.class)
+                            .apply(inputFormula);
+
+            default -> {
+                System.out.printf("Unknown translation type '%s'%n", translation);
+                return;
+            }
+        }
+
+        var automataString = HoaWriter.toString(automaton);
         System.out.println(automataString);
 
 //        // write string to file


### PR DESCRIPTION
## Summary
- extend gfmMinimisation to generate several automata types
- support dela, dpa, dra, nba and ldba via a switch
- construct DRAs using the Rabinizer builder

## Testing
- `./gradlew test --no-daemon` *(fails: Could not download toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_686f7cc9094c8331ae666b104378047b